### PR TITLE
SLES 15 SP3 w/ Docker 20.10.6

### DIFF
--- a/ami_sles15_sp3.json
+++ b/ami_sles15_sp3.json
@@ -1,0 +1,51 @@
+{
+  "variables": {
+    "name": "suse-sles-15-sp3-docker-20.10.6-gp2",
+    "source_ami": "ami-0c75f1fdabc7cc5f4",
+    "access_key": "",
+    "secret_key": "",
+    "region": "us-east-2"
+  },
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "access_key": "{{user `access_key`}}",
+      "secret_key": "{{user `secret_key`}}",
+      "ami_name": "{{user `name`}}",
+      "region": "{{user `region`}}",
+      "ami_regions": [
+        "us-east-2"
+      ],
+      "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/sda1",
+          "volume_size": 12,
+          "volume_type": "gp2",
+          "delete_on_termination": true
+        }
+      ],
+      "source_ami": "{{user `source_ami`}}",
+      "instance_type": "t2.medium",
+      "communicator": "ssh",
+      "ssh_username": "ec2-user",
+      "force_deregister": true,
+      "run_tags": {
+        "Name": "packer-image"
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [
+        "sudo usermod -aG docker ec2-user"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "cat /etc/docker/daemon.json | jq 'del(.\"storage-driver\")' 2> /dev/null | sudo tee /etc/docker/daemon.json"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Produces image based on official Amazon `ami-0c75f1fdabc7cc5f4` suse-sles-15-sp3-chost-byos-v20210629-hvm-ssd-x86_64 with following mods:
* uses gp2 volume
* ec2-user added into docker group
* removed storage-driver from docker.json