### PR TITLE
openSUSE Leap 15.3 w/ Docker 20.10.6

### DIFF
--- a/ami_opensuse153.json
+++ b/ami_opensuse153.json
@@ -1,0 +1,48 @@
+{
+    "variables": {
+      "name": "opensuse-leap-15.3-docker-20.10.6-gp2",
+      "source_ami": "ami-0f0a403b0c7f19d12",
+      "access_key":"",
+      "secret_key":"",
+      "region":"us-east-2"
+    },
+    "builders": [{
+      "type": "amazon-ebs",
+      "access_key": "{{user `access_key`}}",
+      "secret_key":"{{user `secret_key`}}",
+      "ami_name": "{{user `name`}}",
+      "region": "{{user `region`}}",
+      "ami_regions": [
+        "us-east-2"
+      ],
+      "launch_block_device_mappings": [
+        {
+          "device_name": "/dev/sda1",
+          "volume_size": 12,
+          "volume_type": "gp2",
+          "delete_on_termination": true
+        }
+      ],
+      "source_ami": "{{user `source_ami`}}",
+      "instance_type": "t2.medium",
+      "communicator": "ssh",
+      "ssh_username": "ec2-user",
+      "force_deregister": true,
+      "run_tags":{"Name":"packer-image"}
+    }],
+    "provisioners": [
+        {
+            "type": "shell",
+            "inline": ["sudo zypper -n ref && sudo zypper -n up --no-recommends"]
+        },
+        {
+            "type": "shell",
+            "inline": ["sudo usermod -aG docker ec2-user"]
+        },
+	{
+            "type": "shell",
+            "inline": ["sudo systemctl enable --now docker"]
+        }
+
+]
+  }


### PR DESCRIPTION
Produces image based on official Amazon ami-0f0a403b0c7f19d12 openSUSE-Leap-15-3-v20210708-hvm-ssd-x86_64-5535c495-72d4-4355-b169-54ffa874f849 with following mods:

* uses gp2 volume
* performs system refresh and update
* ec2-user added into docker group
* starts docker service